### PR TITLE
Setting workers while run under docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "egg-scripts start --daemon --title=egg-server-nebula-graph-studio --workers=3",
-    "docker-start": "egg-scripts start --title=egg-server-nebula-graph-studio",
+    "docker-start": "egg-scripts start --title=egg-server-nebula-graph-studio --workers=3",
     "stop": "egg-scripts stop --title=egg-server-nebula-graph-studio",
     "dev": "egg-bin dev -r egg-ts-helper/register",
     "debug": "egg-bin debug -r egg-ts-helper/register",


### PR DESCRIPTION
Just like normal startup, simply using --workers=3 for startup under docker.
This for less memory required while host has lots CPU cores.

issue: #22

Signed-off-by: Ji Bin <matrixji@live.com>