### PR TITLE
fix: update dev server port

### DIFF
--- a/server/config/example-config.yaml
+++ b/server/config/example-config.yaml
@@ -4,4 +4,4 @@ web:
 #  tasks_dir:
 #  sqlitedb_file_path:
 #  ip:
-  port: 7001
+  port: 9000


### PR DESCRIPTION
The default port of the configuration file is incorrect. As a result, the local service cannot be accessed.