### PR TITLE
update license term from "MIT" to "Apache 2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,5 @@
   "eslintIgnore": [
     "coverage"
   ],
-  "license": "MIT"
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
there seems no reason to use MIT license here