### PR TITLE
doc: fix English documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kill -9 $(lsof -t -i :7001)
 
 ## Documentation 
 [中文](https://docs.nebula-graph.com.cn/3.1.0/nebula-studio/about-studio/st-ug-what-is-graph-studio/)
-[ENGLISH](https://https://docs.nebula-graph.io/3.1.0/nebula-studio/about-studio/st-ug-what-is-graph-studio/)
+[ENGLISH](https://docs.nebula-graph.io/3.1.0/nebula-studio/about-studio/st-ug-what-is-graph-studio/)
 
 ## Contributing
 Contributions are warmly welcomed and greatly appreciated. Please see [Guide Docs](https://github.com/vesoft-inc/nebula-studio/blob/master/CONTRIBUTING.md) 


### PR DESCRIPTION
see
https://github.com/vesoft-inc/nebula-studio/issues/276

the result after changed the link:
![image](https://user-images.githubusercontent.com/5738175/185056812-bb1e07e8-724a-42e6-882c-a976cec8bf52.png)
