### PR TITLE
fix: fix alter property limit in edit page

### DIFF
--- a/app/pages/Schema/SchemaConfig/Edit/CommonEdit/PropertiesRow.tsx
+++ b/app/pages/Schema/SchemaConfig/Edit/CommonEdit/PropertiesRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AlterType, IProperty } from '@app/interfaces/schema';
 import { useI18n } from '@vesoft-inc/i18n';
 import { nameRulesFn, numberRulesFn, stringByteRulesFn } from '@app/config/rules';
-import { DATA_TYPE, EXPLAIN_DATA_TYPE } from '@app/utils/constant';
+import { DataTypeTransformMap, DATA_TYPE, EXPLAIN_DATA_TYPE } from '@app/utils/constant';
 
 import styles from './index.module.less';
 const Option = Select.Option;
@@ -102,8 +102,11 @@ export const EditRow = (props: IEditProps) => {
                     message: intl.get('formRules.dataTypeRequired'),
                   },
                 ]}>
-                <Select showSearch={true} onChange={onUpdateType} dropdownMatchSelectWidth={false}>
+                <Select disabled={!Object.keys(DataTypeTransformMap).includes(type)} showSearch={true} onChange={onUpdateType} dropdownMatchSelectWidth={false}>
                   {DATA_TYPE.map(item => {
+                    if(!DataTypeTransformMap[type]?.includes(item.value) || item.value !== type) {
+                      return null;
+                    }
                     return (
                       <Option value={item.value} key={item.value}>
                         {item.label}

--- a/app/pages/Schema/SchemaConfig/Edit/CommonEdit/PropertiesRow.tsx
+++ b/app/pages/Schema/SchemaConfig/Edit/CommonEdit/PropertiesRow.tsx
@@ -102,7 +102,7 @@ export const EditRow = (props: IEditProps) => {
                     message: intl.get('formRules.dataTypeRequired'),
                   },
                 ]}>
-                <Select disabled={!Object.keys(DataTypeTransformMap).includes(type)} showSearch={true} onChange={onUpdateType} dropdownMatchSelectWidth={false}>
+                <Select disabled={!(type in DataTypeTransformMap)} showSearch={true} onChange={onUpdateType} dropdownMatchSelectWidth={false}>
                   {DATA_TYPE.map(item => {
                     if(!DataTypeTransformMap[type]?.includes(item.value) || item.value !== type) {
                       return null;

--- a/app/utils/constant.ts
+++ b/app/utils/constant.ts
@@ -109,7 +109,7 @@ export const DataTypeTransformMap = {
   int32: ['int'],
   fixed_string: ['string'],
   float: ['double'],
-};
+} as const;
 
 export const DATA_TYPE = [
   {

--- a/app/utils/constant.ts
+++ b/app/utils/constant.ts
@@ -103,6 +103,14 @@ export const ENUM_OF_COMPARE = {
   ],
 };
 
+export const DataTypeTransformMap = {
+  int8: ['int16', 'int32', 'int'],
+  int16: ['int32', 'int'],
+  int32: ['int'],
+  fixed_string: ['string'],
+  float: ['double'],
+};
+
 export const DATA_TYPE = [
   {
     value: 'int',

--- a/server/api/studio/pkg/client/pool.go
+++ b/server/api/studio/pkg/client/pool.go
@@ -479,6 +479,9 @@ func parseExecuteData(response SingleResponse) (ParsedResult, error) {
 		return result, nil
 	}
 
+	if !res.IsSucceed() {
+		return result, errors.New(res.GetErrorMsg())
+	}
 	if res.IsSetPlanDesc() {
 		resp := response.Result
 		if response.Result == nil {
@@ -509,9 +512,6 @@ func parseExecuteData(response SingleResponse) (ParsedResult, error) {
 			result.Tables = append(result.Tables, rowValue)
 			return result, nil
 		}
-	}
-	if !res.IsSucceed() {
-		return result, errors.New(res.GetErrorMsg())
 	}
 	if !res.IsEmpty() {
 		rows := res.GetRows()


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
disable to modify the data types that do not meet the requirements, and filter the data types that are allowed to be converted
[doc](https://docs.nebula-graph.com.cn/3.4.1/3.ngql-guide/10.tag-statements/3.alter-tag/)
<img width="764" alt="image" src="https://user-images.githubusercontent.com/18328704/228458077-ca12bbd0-8ff3-45fc-9150-c2ba79ff216c.png">

![image](https://user-images.githubusercontent.com/18328704/228457965-99d6dfb9-80e3-4959-87f6-81c2f29d350f.png)


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


