### PR TITLE
feat: Modify the console page graph display(enhancement)

### DIFF
--- a/app/pages/Console/OutputBox/ForceGraph/index.module.less
+++ b/app/pages/Console/OutputBox/ForceGraph/index.module.less
@@ -10,6 +10,7 @@
   height: 100%;
   flex: auto;
   overflow: hidden;
+  background: #F9FCFF;
 }
 
 .graphLoading {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vesoft-inc/force-graph": "2.0.7",
         "@vesoft-inc/i18n": "^1.0.1",
         "@vesoft-inc/icons": "^1.2.0",
-        "@vesoft-inc/nebula-explain-graph": "^1.0.2-beta.2",
+        "@vesoft-inc/nebula-explain-graph": "^1.0.2-beta.6",
         "@vesoft-inc/veditor": "^4.4.12",
         "antd": "^5.8.4",
         "axios": "^0.23.0",
@@ -2063,11 +2063,11 @@
       "integrity": "sha512-tqoAlsc1ofmaawQL15ok98wlAzD5NAWSPu5RBva85jvw7XREJM5+VjYeOg9lYAEWsdraUvw4iFNMBY9GvZtXhA=="
     },
     "node_modules/@vesoft-inc/nebula-explain-graph": {
-      "version": "1.0.2-beta.2",
-      "resolved": "https://registry.npmmirror.com/@vesoft-inc/nebula-explain-graph/-/nebula-explain-graph-1.0.2-beta.2.tgz",
-      "integrity": "sha512-Pgcun3Zkq/pQ0dNzfStRmhRa2HH2hZOLB7878HZPnZ2cGSfRWM5XhuO5JsnrZMhgdbuoINQ1iuHK1T61+m2hvg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vesoft-inc/nebula-explain-graph/-/nebula-explain-graph-1.0.2.tgz",
+      "integrity": "sha512-BJLY8ZFegjfAYfMlb2xhcF2kYQkXDKa5YLs4Q+Mb01baVSucaeHp62RhvfonZ5nf6bcJKQUjrskSR88mNJQh6Q==",
       "peerDependencies": {
-        "@vesoft-inc/veditor": "^4.4.11",
+        "@vesoft-inc/veditor": "^4.4.8",
         "antd": "^4||^5",
         "copy-to-clipboard": "^3.3.3",
         "react": "^17||^18",
@@ -10500,9 +10500,9 @@
       "integrity": "sha512-tqoAlsc1ofmaawQL15ok98wlAzD5NAWSPu5RBva85jvw7XREJM5+VjYeOg9lYAEWsdraUvw4iFNMBY9GvZtXhA=="
     },
     "@vesoft-inc/nebula-explain-graph": {
-      "version": "1.0.2-beta.2",
-      "resolved": "https://registry.npmmirror.com/@vesoft-inc/nebula-explain-graph/-/nebula-explain-graph-1.0.2-beta.2.tgz",
-      "integrity": "sha512-Pgcun3Zkq/pQ0dNzfStRmhRa2HH2hZOLB7878HZPnZ2cGSfRWM5XhuO5JsnrZMhgdbuoINQ1iuHK1T61+m2hvg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vesoft-inc/nebula-explain-graph/-/nebula-explain-graph-1.0.2.tgz",
+      "integrity": "sha512-BJLY8ZFegjfAYfMlb2xhcF2kYQkXDKa5YLs4Q+Mb01baVSucaeHp62RhvfonZ5nf6bcJKQUjrskSR88mNJQh6Q==",
       "requires": {}
     },
     "@vesoft-inc/veditor": {


### PR DESCRIPTION
Modify the console page to run the ngql query statement. If there is a graph, the graph will be displayed by default, as well as the background color of the graph. In addition, the displayed full-screen icon has been moved to the header of the outbox.

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #312 


#### Description:
Originally, the table was displayed by default,  the graph background was a little gray,  and making the full-screen icon difficult to spot.

## How do you solve it?
Modify the console page to run the ngql query statement. If there is a graph, the graph will be displayed by default, as well as the background color(#F9FCFF) of the graph. In addition, the displayed full-screen icon has been moved to the header of the outbox.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:
![image](https://github.com/vesoft-inc/nebula-studio/assets/36021958/eec6275c-99eb-4093-9ee8-2ea4172ffb26)


