### PR TITLE
prompt: default prompt for KG builder

### DIFF
--- a/server/api/studio/etc/ai-importer.yaml
+++ b/server/api/studio/etc/ai-importer.yaml
@@ -15,18 +15,25 @@ MaxBlockSize: 0 # max request block num
 GQLBatchSize: 100 # max gql batch size
 PromptTemplate: |
     As a knowledge graph AI importer, your task is to extract useful data from the following text:
-    ----text
+    
+    ---
     {text}
-    ----
+    ---
 
-    the knowledge graph has following schema and node name must be a real :
-    ----graph schema
+    The knowledge graph should follow this schema (node name is mandatory):
+
+    ---
     {spaceSchema}
-    ----
+    ---
 
-    Return the results directly, without explain and comment. The results should be in the following JSON format:
+    Please return the results in JSON format only, without any explanations or comments. The JSON should include nodes and edges with their properties, as shown below:
+
+    ```json
     {
-      "nodes":[{ "name":string,"type":string,"props":object }],
-      "edges":[{ "src":string,"dst":string,"edgeType":string,"props":object }]
+      "nodes":[{ "name":"foo","type":"node_type_1","props":{"key_x":"85%"} }],
+      "edges":[{ "src":"foo","dst":"bar","edgeType":"edge_type_3","props":{"name":"is located in"} }]
     }
-    the result json is:
+    ```
+
+    Ensure the JSON is correctly formatted. Now, extract!
+    JSON:

--- a/server/api/studio/etc/studio-api.yaml
+++ b/server/api/studio/etc/studio-api.yaml
@@ -65,17 +65,27 @@ LLM:
   MaxBlockSize: 0
   PromptTemplate: |
     As a knowledge graph AI importer, your task is to extract useful data from the following text:
-    ```text
+
+    ---
     {text}
-    ```
-    the knowledge graph has following schema and node name must be a real :
-    ```graph-schema
+    ---
+
+    The knowledge graph should follow this schema (node name is mandatory):
+
+    ---
     {spaceSchema}
-    ```
+    ---
+
     {userPrompt}
-    Return the results directly, without explain and comment. The results should be in the following JSON format:
+
+    Please return the results in JSON format only, without any explanations or comments. The JSON should include nodes and edges with their properties, as shown below:
+
+    ```json
     {
-      "nodes":[{ "name":string,"type":string,"props":object }],
-      "edges":[{ "src":string,"dst":string,"edgeType":string,"props":object }]
+      "nodes":[{ "name":"foo","type":"node_type_1","props":{"key_x":"85%"} }],
+      "edges":[{ "src":"foo","dst":"bar","edgeType":"edge_type_3","props":{"name":"is located in"} }]
     }
-    the result json is:
+    ```
+    
+    Ensure the JSON is correctly formatted. Now, extract!
+    JSON:


### PR DESCRIPTION
Previously, due to the fact we assumed "name" is special for an extracted node to actually act as its vertexID, and, there in NebulaGraph the id is actually composite 4 fields(src,dst,type,rank), thus it failed to extract "name" in edges.

In such case, the "name" field in schema of edge type will not be handled properly in some of LLMs.

Also, previously, the JSON format was not exactly an example, but a half example(nodes, edges) half json type schema(xxx:string, yyy:object).

This is actually not clear enough, which will cost mind-power of LLMs.

Now it's changed to a real example.

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:  #746 

---------

To quicly verify this works fine on other (local) LLMs, paste this prompt:

```
As a knowledge graph AI importer, your task is to extract useful data from the following text:

---
What I Worked On
February 2021
Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined made them deep.
The first programs I tried writing were on the IBM 1401 that our school district used for what was then called "data processing." This was in 9th grade, so I was 13 or 14. The school district's 1401 happened to be in the basement of our junior high school, and my friend Rich Draves and I got permission to use it. It was like a mini Bond villain's lair down there, with all these alien-looking machines — CPU, disk drives, printer, card reader — sitting up on a raised floor under bright fluorescent lights.
---

The knowledge graph has the following schema, and node name is mandatory:

---
NodeType "entity" ("name":string )
EdgeType "relationship" ("name":string )
---

Only return the JSON, without explain or comment. The results should be in the following JSON format, where `"props":{...}` stands for JSON object format properties of the node or edge:

\```json
{
  "nodes":[{ "name":string,"type":string,"props":{...} }],
  "edges":[{ "src":string,"dst":string,"edgeType":string,"props":{...} }]
}
\```

Ensure the JSON is correctly formatted. Now, extract!
JSON:
```

