### PR TITLE
chore: hide the llm import feature in cloud

### DIFF
--- a/app/pages/Import/index.tsx
+++ b/app/pages/Import/index.tsx
@@ -5,6 +5,7 @@ import { trackPageView } from '@app/utils/stat';
 import cls from 'classnames';
 import { useI18n } from '@vesoft-inc/i18n';
 import llm from '@app/stores/llm';
+import { useStore } from '@app/stores';
 import DatasourceList from './DatasourceList';
 import styles from './index.module.less';
 import TaskList from './TaskList';
@@ -14,9 +15,12 @@ const Import = () => {
   const location = useLocation();
   const [tab, setTab] = useState('tasks');
   const { intl } = useI18n();
+  const { global: { platform }} = useStore();
   useEffect(() => {
     trackPageView('/import');
-    llm.fetchConfig();
+    if (platform !== 'cloud') {
+      llm.fetchConfig();
+    }
   }, []);
   useEffect(() => {
     const path = location.pathname;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
before:
<img width="1227" alt="image" src="https://github.com/vesoft-inc/nebula-studio/assets/8124783/3e4ca4f0-1364-43d0-9696-8129f418ad3f">

after:
<img width="1160" alt="image" src="https://github.com/vesoft-inc/nebula-studio/assets/8124783/fc6ecd36-8408-47a6-b2c1-aad806d66d2a">


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


