### PR TITLE
remove planDesc parsing logic temporarily

### DIFF
--- a/server-v5/api/studio/internal/service/gateway.go
+++ b/server-v5/api/studio/internal/service/gateway.go
@@ -20,13 +20,6 @@ import (
 
 var _ GatewayService = (*gatewayService)(nil)
 
-const (
-	address  = "192.168.8.145"
-	port     = 9669
-	username = "root"
-	password = "nebula"
-)
-
 type (
 	GatewayService interface {
 		Connect(req *types.ConnectDBParams) error
@@ -91,20 +84,12 @@ func (s *gatewayService) Disconnect() (*types.AnyResp, error) {
 func (g *gatewayService) ExecGQL(request *types.ExecGQLParams) (*types.AnyResp, error) {
 	authData := g.ctx.Value(auth.CtxKeyUserInfo{}).(*auth.AuthData)
 	host := fmt.Sprintf("%s:%d", authData.Address, authData.Port)
-	client, err := nebula.NewNebulaClient(host, username, password)
+	client, err := nebula.NewNebulaClient(host, authData.Username, authData.Password)
 	if err != nil {
 		return nil, err
 	}
 	defer client.Close()
 
-	// gql := strconv.Quote(request.Gql)
-	// gql = gql[1 : len(gql)-1]
-	// gql = strings.ReplaceAll(gql, "\\n", " ")
-	// gql = strings.ReplaceAll(gql, "\\t", " ")
-	// gql = strings.ReplaceAll(gql, "\\r", " ")
-	// gql = strings.ReplaceAll(gql, "\\\\", " ")
-	// fmt.Println("=====request.Gql", request.Gql)
-	// fmt.Println("=====request.gql", gql)
 	resp, err := graphd.RunGql(client, request.Gql)
 	if err != nil {
 		return nil, ecode.WithErrorMessage(ecode.ErrInternalServer, err, "run gql failed")

--- a/server-v5/api/studio/internal/service/gateway.go
+++ b/server-v5/api/studio/internal/service/gateway.go
@@ -44,9 +44,10 @@ type (
 
 func NewGatewayService(ctx context.Context, svcCtx *svc.ServiceContext) GatewayService {
 	return &gatewayService{
-		Logger: logx.WithContext(ctx),
-		ctx:    ctx,
-		svcCtx: svcCtx,
+		Logger:           logx.WithContext(ctx),
+		ctx:              ctx,
+		svcCtx:           svcCtx,
+		withErrorMessage: utils.ErrMsgWithLogger(ctx),
 	}
 }
 

--- a/server-v5/api/studio/pkg/auth/authorize.go
+++ b/server-v5/api/studio/pkg/auth/authorize.go
@@ -102,6 +102,10 @@ func ParseConnectDBParams(params *types.ConnectDBParams, config *config.Config) 
 	if err != nil {
 		return "", err
 	}
+	err = client.Ping()
+	if err != nil {
+		return "", err
+	}
 	defer client.Close()
 
 	tokenString, err := CreateToken(

--- a/server-v5/api/studio/pkg/graphd/resultparser/explain/parser.go
+++ b/server-v5/api/studio/pkg/graphd/resultparser/explain/parser.go
@@ -6,11 +6,5 @@ import (
 )
 
 func Parser(v nebula.Result, r *types.ParsedResult) error {
-	planDesce := v.PlanDesc()
-	if planDesce == nil {
-		return nil
-	}
-
-	r.PlanDesc = string(planDesce)
 	return nil
 }

--- a/server-v5/go.mod
+++ b/server-v5/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vesoft-inc/go-pkg v0.0.0-20231117110005-307b542ecb31
-	github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240328015426-7d541ef7a0ce
+	github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240408053848-e595d9ac84bb
 	github.com/zeromicro/go-zero v1.6.3
 	gorm.io/gorm v1.25.7
 )
@@ -21,7 +21,6 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-playground/assert/v2 v2.2.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.10.1 // indirect

--- a/server-v5/go.sum
+++ b/server-v5/go.sum
@@ -105,8 +105,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vesoft-inc/go-pkg v0.0.0-20231117110005-307b542ecb31 h1:bYwFepB7fc/hxVw2c47Q1fBEv2/6kf9A8K+LzfG57bs=
 github.com/vesoft-inc/go-pkg v0.0.0-20231117110005-307b542ecb31/go.mod h1:eLgC+U4ipJ1fxCYBxa1qkuocl5TPswpq192Pdo56lKY=
-github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240328015426-7d541ef7a0ce h1:HLT1ZLsIj+00xbHtPYW/TMzErn5h99PJH8OH5U3ZMI4=
-github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240328015426-7d541ef7a0ce/go.mod h1:Lz1q3qT/ByxroHgXvL+i7kHfpa32dXkdcDrg2xc/LVs=
+github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240408053848-e595d9ac84bb h1:hxBcjZ2ZlBTwq0CAua1q5DQJcp9NDeaIhrexXDIlkA8=
+github.com/vesoft-inc/nebula-ng-tools/golang v0.0.0-20240408053848-e595d9ac84bb/go.mod h1:N6cozbQ/y0ryBcgOwwZMaVHEyt82JcD78ZtxIsPcXRs=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeromicro/go-zero v1.6.3 h1:OL0NnHD5LdRNDolfcK9vUkJt7K8TcBE3RkzfM8poOVw=

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import Button from '@mui/material/Button';
+import LoadingButton from '@mui/lab/LoadingButton';
+import SaveIcon from '@mui/icons-material/Save';
 import { FormContainer, PasswordElement, TextFieldElement, useForm } from 'react-hook-form-mui';
 import { Grid } from '@mui/material';
 import { useStore } from '@/stores';
@@ -29,13 +30,18 @@ interface LoginFormData {
 export default function Login() {
   const navigate = useNavigate();
   const { commonStore } = useStore();
+  const [loading, setLoading] = useState(false);
   const { t } = useTranslation(['login', 'common']);
   const form = useForm<LoginFormData>({ defaultValues: { address: '', username: '', password: '', port: '9669' } });
   const onSubmit = useCallback(async (data: LoginFormData) => {
+    setLoading(true);
     const flag = await commonStore.login(data);
     const params = new URLSearchParams(location.search);
     const redirect = params.get('redirect') || '/console';
-    flag && navigate(redirect);
+    setTimeout(() => {
+      flag && navigate(redirect);
+      setLoading(false);
+    }, 300);
   }, []);
 
   return (
@@ -90,16 +96,19 @@ export default function Login() {
                 />
               </Grid>
               <Grid item md={12}>
-                <Button
+                <LoadingButton
                   onClick={form.handleSubmit(onSubmit)}
                   variant="contained"
                   fullWidth
                   size="large"
                   sx={{ marginTop: ({ spacing }) => spacing(2) }}
                   type="submit"
+                  loadingPosition="start"
+                  startIcon={<SaveIcon />}
+                  loading={loading}
                 >
                   {t('login', { ns: 'login' })}
-                </Button>
+                </LoadingButton>
               </Grid>
             </Grid>
           </FormContainer>

--- a/src/stores/_ref.ts
+++ b/src/stores/_ref.ts
@@ -1,0 +1,12 @@
+import type { RootStore } from '@/stores';
+
+const rootStoreRef = { current: undefined as unknown as RootStore };
+
+export const getRootStore = () => rootStoreRef.current;
+
+export const setRootStore = (store: RootStore) => {
+  if (rootStoreRef.current) {
+    throw new Error('`rootStore` has been set already');
+  }
+  rootStoreRef.current = store;
+};

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 import { RouterStore, themeStore } from '@vesoft-inc/utils';
 import { ModalStore } from '@vesoft-inc/ui-components';
+import { setRootStore, getRootStore } from './_ref';
 import { CommonStore } from './common';
 import GraphTypeStore from './graphtype';
 import { ConsoleStore } from './console';
@@ -16,12 +17,12 @@ export class RootStore {
 
 const rootStore = new RootStore();
 
-const rootStoreRef = { current: rootStore };
+setRootStore(rootStore);
 
 // @ts-ignore
 window.studioStore = rootStore;
 
-export const getRootStore = () => rootStoreRef.current;
+export { getRootStore };
 export const storeContext = createContext(rootStore);
 export const StoreProvider = storeContext.Provider;
 export function useStore() {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
- vesoft-inc/nebula-studio-ent#532 

#### Description:
- Must execute `client.Ping()` after Client instance initiation
- Due to breaking changes of protocol, temporarily remove the parsing logic for `planDesc`

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


