### PR TITLE
Set base path for Vite configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ const htmlPlugin = (data?: Record<string, unknown>): Plugin => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+   base: './', 
   build: {
     target: 'esnext',
     sourcemap: true,


### PR DESCRIPTION
This allows nebula studio to run behind nginx reverse proxy as all the assets are now loaded from relative paths



## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement



Right Now the Nebula Studio does not run behind an NGNX reverse proxy if it has a sub path because all the paths inside this index HTML are absolute paths. We need to have a relative path to load the studio from a sub directory or a sub path
